### PR TITLE
Remove boost-filesystem

### DIFF
--- a/yosys-plugin/Makefile
+++ b/yosys-plugin/Makefile
@@ -1,5 +1,5 @@
 churchroad.so: churchroad.cc
-	$(CXX) $(shell yosys-config --cxxflags --ldflags) -shared -o $@ churchroad.cc -lboost_filesystem
+	$(CXX) $(shell yosys-config --cxxflags --ldflags) -shared -o $@ churchroad.cc
 
 clean:
 	rm -rfv *.d *.o churchroad.so*


### PR DESCRIPTION
We don't need this anymore, because it's no longer used in `yosys-plugin/churchroad.cc`!