### PR TITLE
Add ifu_esl_counter which demonstrates a bug with extracting with cycles

### DIFF
--- a/yosys-plugin/tests/ifu_esl_counter/README.md
+++ b/yosys-plugin/tests/ifu_esl_counter/README.md
@@ -1,0 +1,3 @@
+# Replicates a bug where extraction with cycles don't work
+- Run `egglog ./ifu_esl_counter_example_synth.egg` to see the extraction bug
+

--- a/yosys-plugin/tests/ifu_esl_counter/ifu_esl_counter.pickle.v
+++ b/yosys-plugin/tests/ifu_esl_counter/ifu_esl_counter.pickle.v
@@ -1,0 +1,84 @@
+// Copyright (c) 2015 Princeton University
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//     * Neither the name of Princeton University nor the
+//       names of its contributors may be used to endorse or promote products
+//       derived from this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY PRINCETON UNIVERSITY "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL PRINCETON UNIVERSITY BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/*
+ *   Description:
+ *      This module implements a 16-bit counter to be used by Execution
+ *      Drafting
+ */
+
+module sparc_ifu_esl_counter
+#(
+    parameter   COUNT_BIT_WIDTH = 16
+)
+(
+    input                               clk,
+    input                               rst_n,
+
+    // Counter control
+    input                               step,
+    input                               clear,
+    input                               set,
+
+    // Counter output
+    output reg [COUNT_BIT_WIDTH-1:0]    count_f
+);
+
+    //
+    // Signal Declarations
+    //
+
+    // Counter next state
+    reg [COUNT_BIT_WIDTH-1:0]          count_next;
+
+    //
+    // Sequential logic
+    //
+    
+    // State flip-flops
+    always @ (posedge clk)
+    begin
+        if (~rst_n)
+            count_f <= {COUNT_BIT_WIDTH{1'b0}};
+        else
+            count_f <= count_next;
+    end
+
+    //
+    // Combinational logic
+    //
+
+    always @ *
+    begin
+        count_next = count_f;
+        if (clear)
+            count_next = {COUNT_BIT_WIDTH{1'b0}};
+        else if (set)
+            count_next = {{(COUNT_BIT_WIDTH-1){1'b0}}, 1'b1};
+        else if (step)
+            count_next = count_f + {{(COUNT_BIT_WIDTH-1){1'b0}}, 1'b1};
+    end
+
+endmodule

--- a/yosys-plugin/tests/ifu_esl_counter/ifu_esl_counter_example_synth.egg
+++ b/yosys-plugin/tests/ifu_esl_counter/ifu_esl_counter_example_synth.egg
@@ -1,0 +1,88 @@
+(include "../../../egglog_src/churchroad.egg")
+
+; wire declarations
+; $0\count_f[15:0]
+(let v0 (Wire "v0" 16))
+; $2\count_next[15:0]
+(let v1 (Wire "v1" 16))
+; $3\count_next[15:0]
+(let v2 (Wire "v2" 16))
+; $add$ifu_esl_counter.pickle.v:81$4_Y
+(let v3 (Wire "v3" 16))
+; $procmux$15_Y
+(let v4 (Wire "v4" 16))
+; $procmux$6_Y
+(let v5 (Wire "v5" 16))
+; $procmux$9_Y
+(let v6 (Wire "v6" 16))
+; clear
+(let v7 (Wire "v7" 1))
+; clk
+(let v8 (Wire "v8" 1))
+; count_f
+(let v9 (Wire "v9" 16))
+; count_next
+(let v10 (Wire "v10" 16))
+; rst_n
+(let v11 (Wire "v11" 1))
+; sset
+(let v12 (Wire "v12" 1))
+; step
+(let v13 (Wire "v13" 1))
+
+; cells
+; 16'0000000000000001
+(let v14 (Op0 (BV 1 16)))
+(union v3 (Op2 (Add) v9 v14))
+; TODO: assuming 0 default for Reg
+(union v9 (Op2 (Reg 0) v8 v0))
+; 16'x
+(let v15 (Op0 (BV 0 16)))
+(union v2 (Op3 (Mux) v7 v6 v15))
+(union v4 (Op3 (Mux) v12 v2 v14))
+(union v1 (Op3 (Mux) v7 v4 v15))
+; 16'0000000000000000
+(let v16 (Op0 (BV 0 16)))
+(union v10 (Op3 (Mux) v7 v1 v16))
+(union v0 (Op3 (Mux) v11 v16 v10))
+(union v5 (Op3 (Mux) v13 v9 v3))
+(union v6 (Op3 (Mux) v12 v5 v15))
+
+; inputs
+(let clear (Var "clear" 1))
+(IsPort "" "clear" (Input) clear)
+(union v7 clear)
+(let clk (Var "clk" 1))
+(IsPort "" "clk" (Input) clk)
+(union v8 clk)
+(let rst_n (Var "rst_n" 1))
+(IsPort "" "rst_n" (Input) rst_n)
+(union v11 rst_n)
+(let sset (Var "sset" 1))
+(IsPort "" "sset" (Input) sset)
+(union v12 sset)
+(let step (Var "step" 1))
+(IsPort "" "step" (Input) step)
+(union v13 step)
+
+; outputs
+(let count_f v9)
+(IsPort "" "count_f" (Output) count_f)
+
+; delete wire expressions
+(delete (Wire "v0" 16))
+(delete (Wire "v1" 16))
+(delete (Wire "v2" 16))
+(delete (Wire "v3" 16))
+(delete (Wire "v4" 16))
+(delete (Wire "v5" 16))
+(delete (Wire "v6" 16))
+(delete (Wire "v7" 1))
+(delete (Wire "v8" 1))
+(delete (Wire "v9" 16))
+(delete (Wire "v10" 16))
+(delete (Wire "v11" 1))
+(delete (Wire "v12" 1))
+(delete (Wire "v13" 1))
+
+(extract count_f)

--- a/yosys-plugin/tests/ifu_esl_counter/ifu_esl_counter_script.ys
+++ b/yosys-plugin/tests/ifu_esl_counter/ifu_esl_counter_script.ys
@@ -1,0 +1,6 @@
+read_verilog -sv ifu_esl_counter.pickle.v;
+
+proc;
+splice; splitnets -driver;
+
+write_lakeroad ifu_esl_counter.egg


### PR DESCRIPTION
Also, demonstrates a bug where Verilog variables include keywords (i.e. `set` )